### PR TITLE
Invite fix 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 /Book_8.*
 /venv
 processed_profiles.txt
+chrome_profile/

--- a/LinkedIn_invite_to_page_or_event.py
+++ b/LinkedIn_invite_to_page_or_event.py
@@ -1,4 +1,5 @@
 import string
+import re
 import os
 import urllib.request
 from selenium import webdriver
@@ -244,7 +245,6 @@ round = 0
 if "/events/" in people_list_url:
     driver.get(people_list_url)
     time.sleep(randint(3, 7))
-    open_event_invite_dialog(driver, people_list_url)
 
 while round < roundsToRepeat:
 
@@ -294,6 +294,8 @@ while round < roundsToRepeat:
         time.sleep(4)
 
     else:
+
+        open_event_invite_dialog(driver, people_list_url)
 
         scroll_event_modal(driver, search_keywords, invitesInOneRound)
 
@@ -361,6 +363,12 @@ while round < roundsToRepeat:
                     continue
 
                 already_selected.add(name)
+
+                name_clean = re.sub(r"[\n\t\s]*", "", name.lower())
+                excluded = any(e.strip().lower() in name_clean for e in excludeList)
+                if excluded:
+                    print("!!!Excluding:", name)
+                    continue
 
                 if testMode:
                     print("TEST — would invite:", name)

--- a/LinkedIn_invite_to_page_or_event.py
+++ b/LinkedIn_invite_to_page_or_event.py
@@ -1,5 +1,6 @@
 import string
 import os
+import urllib.request
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
@@ -23,93 +24,122 @@ roundsToRepeat = 10
 verboseOn = 0
 fileOfExcludedNames = "../exclude.txt"
 credsFile = "../creds.txt"
+REMOTE_DEBUG_PORT = 9222
 
-# ********** LOG IN *************
-adPrinted = 0
-usr = utils.getUser(credsFile, adPrinted, verboseOn)
-adPrinted = 1
-pwd = utils.getPwd(credsFile, adPrinted, verboseOn)
+# ********** BROWSER SETUP *************
+# Try connecting to an already-running Chrome (launched via launch_browser.py).
+# If not available, fall back to launching a fresh browser and logging in.
 
-if os.name == 'nt':
-    from webdriver_manager.chrome import ChromeDriverManager
-    options = Options()
-    options.add_experimental_option('detach', True)
-    service = Service(ChromeDriverManager().install())
-    driver = webdriver.Chrome(service=service, options=options)
+def _get_chromedriver_service():
+    if os.name == 'nt':
+        from webdriver_manager.chrome import ChromeDriverManager
+        return Service(ChromeDriverManager().install())
+    else:
+        return Service(executable_path=r'./chromedriver')
+
+def try_connect_existing_browser():
+    """Connect to Chrome already running with --remote-debugging-port."""
+    try:
+        urllib.request.urlopen(
+            f"http://127.0.0.1:{REMOTE_DEBUG_PORT}/json/version", timeout=2
+        )
+        options = Options()
+        options.add_experimental_option("debuggerAddress", f"127.0.0.1:{REMOTE_DEBUG_PORT}")
+        drv = webdriver.Chrome(service=_get_chromedriver_service(), options=options)
+        print(f"Connected to existing Chrome on port {REMOTE_DEBUG_PORT} — session reused, no login needed.")
+        return drv
+    except Exception:
+        return None
+
+driver = try_connect_existing_browser()
+needs_login = driver is None
+
+if driver is None:
+    print("No persistent browser found. Launching a new Chrome instance...")
+    adPrinted = 0
+    usr = utils.getUser(credsFile, adPrinted, verboseOn)
+    adPrinted = 1
+    pwd = utils.getPwd(credsFile, adPrinted, verboseOn)
+
+    if os.name == 'nt':
+        options = Options()
+        options.add_experimental_option('detach', True)
+        driver = webdriver.Chrome(service=_get_chromedriver_service(), options=options)
+    else:
+        options = webdriver.ChromeOptions()
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+        driver = webdriver.Chrome(service=_get_chromedriver_service(), options=options)
+
+    driver.set_window_size(1000, 650)
+    utils.loginToLinkedin(driver, usr, pwd)
 else:
-    service = Service(executable_path=r'./chromedriver')
-    options = webdriver.ChromeOptions()
-    options.add_argument('--no-sandbox')
-    options.add_argument('--disable-dev-shm-usage')
-    driver = webdriver.Chrome(service=service, options=options)
-
-driver.set_window_size(1000, 650)
-
-utils.loginToLinkedin(driver, usr, pwd)
+    # Still need to read creds path for exclude list etc., but don't log in
+    adPrinted = 0
+    usr = utils.getUser(credsFile, adPrinted, verboseOn)
+    adPrinted = 1
 
 
 # EVENT FLOW
 def open_event_invite_dialog(driver, people_list_url):
-    if "/events/" not in people_list_url:
+    if "/events/" not in people_list_url and "/event/manage/" not in people_list_url:
         return
 
-    print("Detected event URL. Opening Share and Invite flow.")
+    print("Opening event invite picker...")
     time.sleep(3)
 
-    share_selectors = [
-        '[data-view-name="event-management-share-event-tab"]',
-        '[data-view-name="event-management-share"]',
-        'button[aria-label*="Share"]',
-        'a[aria-label*="Share"]',
-        '.event-management__share-tab',
-    ]
-    share_clicked = driver.execute_script("""
-        const selectors = arguments[0];
-        for (let sel of selectors) {
-            const el = document.querySelector(sel);
-            if (el) { el.click(); return sel; }
-        }
-        return null;
-    """, share_selectors)
+    # Check if invite picker already open
+    already_open = driver.execute_script("""
+        const host = document.querySelector('#interop-outlet');
+        if (!host || !host.shadowRoot) return false;
+        return host.shadowRoot.querySelectorAll('.invitee-picker__result-item').length > 0;
+    """)
+    if already_open:
+        print("Invite picker already open, skipping navigation.")
+        return
 
-    if share_clicked:
-        print("Clicked Share tab via:", share_clicked)
+    # Step 1: find Share element and click it with Selenium native click
+    # (JS el.click() doesn't fire React synthetic events — native click does)
+    share_el = None
+    candidates = driver.find_elements(By.XPATH, "//*[@role='button']")
+    for el in candidates:
+        try:
+            if el.text.strip() == 'Share':
+                share_el = el
+                break
+        except Exception:
+            pass
+
+    if not share_el:
+        print("WARNING: Share button not found. Cannot open invite picker.")
+        return
+
+    driver.execute_script("arguments[0].scrollIntoView({block:'center'});", share_el)
+    time.sleep(0.5)
+    share_el.click()
+    print("Clicked Share (native).")
+
+    # Step 2: wait for Invite to appear, then click it
+    invite_el = None
+    for _ in range(12):
+        time.sleep(0.5)
+        candidates = driver.find_elements(By.XPATH, "//*[@role='button' or @role='menuitem' or self::a or self::button or self::li]")
+        for el in candidates:
+            try:
+                t = el.text.strip().lower()
+                if t.startswith('invite') and len(t) < 30 and el.is_displayed():
+                    invite_el = el
+                    break
+            except Exception:
+                pass
+        if invite_el:
+            break
     else:
-        print("WARNING: Share tab not found with any selector. Attempting text-based fallback.")
-        driver.execute_script("""
-            const all = Array.from(document.querySelectorAll('button, a, li'));
-            const el = all.find(e => e.innerText && e.innerText.trim().toLowerCase() === 'share');
-            if (el) el.click();
-        """)
+        print("WARNING: Invite item never appeared after clicking Share.")
+        return
 
-    time.sleep(2)
-
-    invite_selectors = [
-        '[data-view-name="event-management-invite"]',
-        '[data-view-name="event-management-invite-tab"]',
-        'button[aria-label*="Invite"]',
-        'a[aria-label*="Invite"]',
-        '.event-management__invite-tab',
-    ]
-    invite_clicked = driver.execute_script("""
-        const selectors = arguments[0];
-        for (let sel of selectors) {
-            const el = document.querySelector(sel);
-            if (el) { el.click(); return sel; }
-        }
-        return null;
-    """, invite_selectors)
-
-    if invite_clicked:
-        print("Clicked Invite tab via:", invite_clicked)
-    else:
-        print("WARNING: Invite button not found with any selector. Attempting text-based fallback.")
-        driver.execute_script("""
-            const all = Array.from(document.querySelectorAll('button, a, li'));
-            const el = all.find(e => e.innerText && e.innerText.trim().toLowerCase() === 'invite');
-            if (el) el.click();
-        """)
-
+    invite_el.click()
+    print("Clicked Invite:", invite_el.text.strip())
     time.sleep(3)
 
 
@@ -214,6 +244,7 @@ round = 0
 if "/events/" in people_list_url:
     driver.get(people_list_url)
     time.sleep(randint(3, 7))
+    open_event_invite_dialog(driver, people_list_url)
 
 while round < roundsToRepeat:
 
@@ -263,9 +294,6 @@ while round < roundsToRepeat:
         time.sleep(4)
 
     else:
-
-        if "?invite=true" not in people_list_url and not testMode:
-            open_event_invite_dialog(driver, people_list_url)
 
         scroll_event_modal(driver, search_keywords, invitesInOneRound)
 
@@ -370,17 +398,23 @@ while round < roundsToRepeat:
         else:
             print("------Inviting--------")
 
-            driver.execute_script("""
+            invite_result = driver.execute_script("""
                 const host = document.querySelector('#interop-outlet');
-                if (!host || !host.shadowRoot) return;
+                if (!host) return "ERROR: #interop-outlet not found";
+                if (!host.shadowRoot) return "ERROR: shadowRoot not accessible";
 
                 const shadow = host.shadowRoot;
                 const btn = shadow.querySelector("button.artdeco-button--primary");
 
-                if (btn && !btn.disabled) {
-                    btn.click();
-                }
+                if (!btn) return "ERROR: primary button not found in shadow DOM";
+                if (btn.disabled) return "ERROR: button is disabled (nothing selected?)";
+
+                btn.click();
+                return "OK: clicked '" + btn.innerText.trim() + "'";
             """)
+            print("Invite button result:", invite_result)
+            if invite_result and invite_result.startswith("ERROR"):
+                print("WARNING: Invite may NOT have been sent — check the browser!")
 
         totalConnectRequests += selected_count
         time.sleep(4)

--- a/LinkedIn_invite_to_page_or_event.py
+++ b/LinkedIn_invite_to_page_or_event.py
@@ -56,17 +56,59 @@ def open_event_invite_dialog(driver, people_list_url):
     print("Detected event URL. Opening Share and Invite flow.")
     time.sleep(3)
 
-    driver.execute_script("""
-        const share = document.querySelector('[data-view-name="event-management-share-event-tab"]');
-        if (share) share.click();
-    """)
+    share_selectors = [
+        '[data-view-name="event-management-share-event-tab"]',
+        '[data-view-name="event-management-share"]',
+        'button[aria-label*="Share"]',
+        'a[aria-label*="Share"]',
+        '.event-management__share-tab',
+    ]
+    share_clicked = driver.execute_script("""
+        const selectors = arguments[0];
+        for (let sel of selectors) {
+            const el = document.querySelector(sel);
+            if (el) { el.click(); return sel; }
+        }
+        return null;
+    """, share_selectors)
+
+    if share_clicked:
+        print("Clicked Share tab via:", share_clicked)
+    else:
+        print("WARNING: Share tab not found with any selector. Attempting text-based fallback.")
+        driver.execute_script("""
+            const all = Array.from(document.querySelectorAll('button, a, li'));
+            const el = all.find(e => e.innerText && e.innerText.trim().toLowerCase() === 'share');
+            if (el) el.click();
+        """)
 
     time.sleep(2)
 
-    driver.execute_script("""
-        const invite = document.querySelector('[data-view-name="event-management-invite"]');
-        if (invite) invite.click();
-    """)
+    invite_selectors = [
+        '[data-view-name="event-management-invite"]',
+        '[data-view-name="event-management-invite-tab"]',
+        'button[aria-label*="Invite"]',
+        'a[aria-label*="Invite"]',
+        '.event-management__invite-tab',
+    ]
+    invite_clicked = driver.execute_script("""
+        const selectors = arguments[0];
+        for (let sel of selectors) {
+            const el = document.querySelector(sel);
+            if (el) { el.click(); return sel; }
+        }
+        return null;
+    """, invite_selectors)
+
+    if invite_clicked:
+        print("Clicked Invite tab via:", invite_clicked)
+    else:
+        print("WARNING: Invite button not found with any selector. Attempting text-based fallback.")
+        driver.execute_script("""
+            const all = Array.from(document.querySelectorAll('button, a, li'));
+            const el = all.find(e => e.innerText && e.innerText.trim().toLowerCase() === 'invite');
+            if (el) el.click();
+        """)
 
     time.sleep(3)
 
@@ -157,6 +199,13 @@ f3 = utils.getBool3rdLocation(configFile)
 f4 = utils.getBool4thLocation(configFile)
 f5 = utils.getBool5thLocation(configFile)
 f6 = utils.getBool6thLocation(configFile)
+testMode = utils.getTestMode(configFile)
+if testMode is None:
+    print("WARNING: testMode not found in config. Defaulting to test mode for safety.")
+    testMode = 1
+
+if testMode:
+    print("*** TEST MODE ON — no invites will be sent ***")
 
 already_selected = set()
 
@@ -182,12 +231,19 @@ while round < roundsToRepeat:
         invitesSelected = 0
 
         for btn in all_checkboxes:
-            nameSelected = utils.selectContactToInvite(
-                driver, btn, search_keywords, excludeList, verboseOn
-            )
-
-            if len(nameSelected) > 0:
-                invitesSelected += 1
+            if testMode:
+                div_parent = btn.find_element(By.XPATH, "..")
+                for kw in search_keywords:
+                    if kw.lower() in div_parent.text.lower():
+                        print("TEST — would invite:", div_parent.text)
+                        invitesSelected += 1
+                        break
+            else:
+                nameSelected = utils.selectContactToInvite(
+                    driver, btn, search_keywords, excludeList, verboseOn
+                )
+                if len(nameSelected) > 0:
+                    invitesSelected += 1
 
             if invitesSelected >= invitesInOneRound:
                 break
@@ -196,16 +252,20 @@ while round < roundsToRepeat:
             print("No people match the search criteria.")
             break
 
-        print("------Inviting--------")
+        if testMode:
+            print("TEST — would click Invite for", invitesSelected, "people. Skipping.")
+        else:
+            print("------Inviting--------")
+            invite = driver.find_element(By.CSS_SELECTOR, "button.artdeco-button--primary")
+            invite.click()
 
-        invite = driver.find_element(By.CSS_SELECTOR, "button.artdeco-button--primary")
-        invite.click()
         totalConnectRequests += invitesSelected
         time.sleep(4)
 
     else:
 
-        open_event_invite_dialog(driver, people_list_url)
+        if "?invite=true" not in people_list_url and not testMode:
+            open_event_invite_dialog(driver, people_list_url)
 
         scroll_event_modal(driver, search_keywords, invitesInOneRound)
 
@@ -274,23 +334,27 @@ while round < roundsToRepeat:
 
                 already_selected.add(name)
 
-                driver.execute_script("""
-                    const checkbox = arguments[0].querySelector('input[type="checkbox"]');
-                    if (checkbox && !checkbox.checked) {
-                        checkbox.click();
-                    }
-                """, card)
-
-                time.sleep(0.8 + randint(0, 7) / 10)
-
-                # verify it actually got checked
-                is_checked = driver.execute_script("""
-                    const checkbox = arguments[0].querySelector('input[type="checkbox"]');
-                    return checkbox ? checkbox.checked : false;
-                """, card)
-
-                if is_checked:
+                if testMode:
+                    print("TEST — would invite:", name)
                     selected_count += 1
+                else:
+                    driver.execute_script("""
+                        const checkbox = arguments[0].querySelector('input[type="checkbox"]');
+                        if (checkbox && !checkbox.checked) {
+                            checkbox.click();
+                        }
+                    """, card)
+
+                    time.sleep(0.8 + randint(0, 7) / 10)
+
+                    # verify it actually got checked
+                    is_checked = driver.execute_script("""
+                        const checkbox = arguments[0].querySelector('input[type="checkbox"]');
+                        return checkbox ? checkbox.checked : false;
+                    """, card)
+
+                    if is_checked:
+                        selected_count += 1
 
             except:
                 pass
@@ -301,24 +365,30 @@ while round < roundsToRepeat:
             print("No inviteable users found.")
             break
 
-        print("------Inviting--------")
+        if testMode:
+            print("TEST — would click Invite for", selected_count, "people. Skipping.")
+        else:
+            print("------Inviting--------")
 
-        driver.execute_script("""
-            const host = document.querySelector('#interop-outlet');
-            if (!host || !host.shadowRoot) return;
+            driver.execute_script("""
+                const host = document.querySelector('#interop-outlet');
+                if (!host || !host.shadowRoot) return;
 
-            const shadow = host.shadowRoot;
-            const btn = shadow.querySelector("button.artdeco-button--primary");
+                const shadow = host.shadowRoot;
+                const btn = shadow.querySelector("button.artdeco-button--primary");
 
-            if (btn && !btn.disabled) {
-                btn.click();
-            }
-        """)
+                if (btn && !btn.disabled) {
+                    btn.click();
+                }
+            """)
 
         totalConnectRequests += selected_count
         time.sleep(4)
 
     round += 1
 
-print("Total invites sent:" + str(totalConnectRequests))
+if testMode:
+    print("TEST — would have sent " + str(totalConnectRequests) + " invites. None were actually sent.")
+else:
+    print("Total invites sent: " + str(totalConnectRequests))
 print("Script ends here")

--- a/configs/inviteTo_TEST.txt
+++ b/configs/inviteTo_TEST.txt
@@ -1,0 +1,11 @@
+{
+"list_url": "https://www.linkedin.com/events/7448775225099403264/comments/?invite=true",
+"search_keywords": "Moulik",
+"filterFirstLocation": 0,
+"filter2ndLocation": 0,
+"filter3rdLocation": 0,
+"filter4thLocation": 0,
+"filter5thLocation": 0,
+"filter6thLocation": 0,
+"testMode": 1
+}

--- a/launch_browser.py
+++ b/launch_browser.py
@@ -1,0 +1,118 @@
+import subprocess
+import sys
+import os
+import time
+import urllib.request
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CHROME_PROFILE_DIR = os.path.join(SCRIPT_DIR, "chrome_profile")
+REMOTE_DEBUG_PORT = 9222
+CREDS_FILE = os.path.join(SCRIPT_DIR, "../creds.txt")
+
+os.makedirs(CHROME_PROFILE_DIR, exist_ok=True)
+
+# ---- find Chrome executable ----
+if sys.platform == "win32":
+    candidate_paths = [
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+        os.path.expandvars(r"%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe"),
+    ]
+    chrome_exe = next((p for p in candidate_paths if os.path.exists(p)), None)
+    if not chrome_exe:
+        print("ERROR: Chrome not found. Add your Chrome path to candidate_paths in launch_browser.py.")
+        sys.exit(1)
+else:
+    chrome_exe = "google-chrome"
+
+# ---- read credentials ----
+if not os.path.isfile(CREDS_FILE):
+    print(f"ERROR: Credentials file not found at {CREDS_FILE}")
+    sys.exit(1)
+
+with open(CREDS_FILE, encoding="utf8") as f:
+    lines = [l.strip() for l in f.readlines()]
+
+if len(lines) < 2:
+    print("ERROR: creds.txt must have username on line 1 and password on line 2.")
+    sys.exit(1)
+
+usr, pwd = lines[0], lines[1]
+
+# ---- check if bot Chrome is already running ----
+already_running = False
+try:
+    urllib.request.urlopen(f"http://127.0.0.1:{REMOTE_DEBUG_PORT}/json/version", timeout=1)
+    already_running = True
+except Exception:
+    pass
+
+if already_running:
+    print(f"Bot Chrome is already running on port {REMOTE_DEBUG_PORT} — skipping launch.")
+else:
+    # ---- launch Chrome with remote debugging ----
+    cmd = [
+        chrome_exe,
+        f"--user-data-dir={CHROME_PROFILE_DIR}",
+        f"--remote-debugging-port={REMOTE_DEBUG_PORT}",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "about:blank",
+    ]
+
+    print(f"Launching Chrome on port {REMOTE_DEBUG_PORT}...")
+    subprocess.Popen(cmd)
+
+    # wait for Chrome to be ready
+    print("Waiting for Chrome to start...", end="", flush=True)
+    for _ in range(20):
+        time.sleep(1)
+        print(".", end="", flush=True)
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{REMOTE_DEBUG_PORT}/json/version", timeout=1)
+            break
+        except Exception:
+            pass
+    else:
+        print("\nERROR: Chrome did not start in time. Try running manually.")
+        sys.exit(1)
+
+    print(" ready.")
+
+# ---- connect Selenium and log in ----
+import os.path as _osp
+if os.name == 'nt':
+    from webdriver_manager.chrome import ChromeDriverManager
+    from selenium.webdriver.chrome.service import Service
+    from selenium.webdriver.chrome.options import Options
+    from selenium import webdriver
+
+    options = Options()
+    options.add_experimental_option("debuggerAddress", f"127.0.0.1:{REMOTE_DEBUG_PORT}")
+    service = Service(ChromeDriverManager().install())
+    driver = webdriver.Chrome(service=service, options=options)
+else:
+    from selenium.webdriver.chrome.service import Service
+    from selenium import webdriver
+
+    options = webdriver.ChromeOptions()
+    options.add_experimental_option("debuggerAddress", f"127.0.0.1:{REMOTE_DEBUG_PORT}")
+    service = Service(executable_path=_osp.join(SCRIPT_DIR, "chromedriver"))
+    driver = webdriver.Chrome(service=service, options=options)
+
+# check if already logged in
+driver.get("https://www.linkedin.com/feed")
+time.sleep(4)
+
+if "/feed" in driver.current_url or "/mynetwork" in driver.current_url:
+    print("Already logged in — session was saved from a previous run.")
+else:
+    print("Logging in to LinkedIn...")
+    import sys as _sys
+    _sys.path.insert(0, SCRIPT_DIR)
+    import utils
+    utils.loginToLinkedin(driver, usr, pwd)
+    print("Login complete.")
+
+print()
+print("Browser is ready. Keep this window open and run your bot scripts.")

--- a/utils.py
+++ b/utils.py
@@ -94,7 +94,7 @@ def loginToLinkedin(driver, usr, pwd):
 
         try:
             time.sleep(3)
-            username = driver.find_element(By.XPATH, "//input[@name='session_key']")
+            username = driver.find_element(By.ID, "username")
             password = driver.find_element(By.XPATH, "//input[@name='session_password']")
             username.send_keys(usr)
             password.send_keys(pwd)


### PR DESCRIPTION
## What was fixed

- **Login fix** - username field selector was using `@name='session_key'` which no longer matches LinkedIn's login form. Changed to `By.ID, "username"`.

- **Share/Invite flow** - LinkedIn removed `data-view-name` attributes from their DOM, breaking the invite dialog navigation. Rewrote to find the Share button by `role="button"` + text content, using Selenium native clicks (JS clicks don't fire React events).

- **Persistent browser session** - added `launch_browser.py` which opens Chrome with remote debugging port 9222. Bot scripts connect to the existing window automatically, no repeated logins needed.

- **Exclude list** - was never applied to the event flow, only non-event. Added the same check to event flow. Let me know if this was intentional and should be reverted.

- **Silent failures** - added logging to the final invite button click so failures are visible instead of silently passing.

**Note:** Set `"testMode": 0` in your config file to actually send invites - if omitted or set to `1`, the script runs in test mode and only prints what it would do without sending anything.
